### PR TITLE
Added config for babel transpiling in node runner for JavaScript

### DIFF
--- a/app/services/runner/runner.service.js
+++ b/app/services/runner/runner.service.js
@@ -26,7 +26,8 @@ class Runner {
             language,
             code,
             fixture: tests,
-            testFramework: testFrameworks[language]
+            testFramework: testFrameworks[language],
+            ...(language === 'javascript' ? {languageVersion: '8.x/babel'} : {})
         };
 
         try {


### PR DESCRIPTION
languageVersion property with value '8.x/babel' say to node-runner, that we should transpile code with babel. It was done for supporting React JSX syntax.